### PR TITLE
feat: add nms module support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,9 @@ Initial release of the NGINX Management Suite Ansible role. Features include:
 
 * Install NGINX Management Suite (NMS).
 * Create initial NMS password.
+
+## 0.2.0 - Add Module support (March 17th, 2023)
+
+Features include:
+
+* Add the ability to optionally install one or more NMS modules.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Working functional playbook examples can be found in the **[`molecule/`](https:/
 | **[`default/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/default/converge.yml)** | Install NGINX OSS and NMS |
 | **[`plus/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus/converge.yml)** | Install NGINX Plus and NMS |
 | **[`upgrade/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/upgrade/converge.yml)** | Upgrade NMS |
+| **[`modules/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/modules/converge.yml)** | Install NGINX OSS and NMS & the API Connectivity Manager module |
 
 Do note that if you install this repository via Ansible Galaxy, you will have to replace the role variable in the sample playbooks from `ansible-role-nginx-management-suite` to `nginxinc.nms`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,11 @@ nms_clickhouse_release_kind: lts
 
 ## By default, NMS certificates are removed by default
 nms_remove_certs: true
+
+## By default, no NMS modules are installed.
+## If version is not set, the latest version is installed.
+## If setup is not set, the value from the nms_setup is used.
+nms_modules: []
+  # - name: nms-api-connectivity-manager
+  #   version: ''
+  #   setup: install

--- a/molecule/modules/converge.yml
+++ b/molecule/modules/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Install NMS & ACM
+      ansible.builtin.include_role:
+        name: ansible-role-nginx-management-suite
+      vars:
+        nms_setup: install
+        nms_user_passwd: 'Password123'
+        nginx_selinux: true
+        nginx_selinux_enforcing: false
+        nms_remove_certs: false
+        nginx_license:
+          certificate: license/nginx-repo.crt
+          key: license/nginx-repo.key
+        nms_modules:
+          - name: nms-api-connectivity-manager

--- a/molecule/modules/molecule.yml
+++ b/molecule/modules/molecule.yml
@@ -1,0 +1,121 @@
+---
+driver:
+  name: docker
+lint: |
+  set -e
+  ansible-lint --force-color .
+platforms:
+  - name: amazonlinux-2
+    image: amazonlinux:2
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: oraclelinux-7
+    image: oraclelinux:7
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: oraclelinux-8
+    image: oraclelinux:8
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: centos-7
+    image: centos:7
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: rhel-7
+    image: registry.access.redhat.com/ubi7/ubi:7.9
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: rhel-8
+    image: redhat/ubi8:8.7
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    platform: x86_64
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: rhel-9
+    image: redhat/ubi9:9.1.0
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: debian-buster
+    image: debian:buster-slim
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bullseye
+    image: debian:bullseye-slim
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-bionic
+    image: ubuntu:bionic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-focal
+    image: ubuntu:focal
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-jammy
+    image: ubuntu:jammy
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml

--- a/molecule/modules/prepare.yml
+++ b/molecule/modules/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create ephemeral license certificate file from b64 decoded env var # noqa template-instead-of-copy
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
+        dest: ../../files/license/nginx-repo.crt
+        force: false
+        mode: "0444"
+
+    - name: Create ephemeral license key file from b64 decoded env var # noqa template-instead-of-copy
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
+        dest: ../../files/license/nginx-repo.key
+        force: false
+        mode: "0444"

--- a/molecule/modules/verify.yml
+++ b/molecule/modules/verify.yml
@@ -1,0 +1,50 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if NGINX is installed
+      ansible.builtin.package:
+        name: nginx
+        state: present
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)
+
+    - name: Check if NGINX service is running
+      ansible.builtin.service:
+        name: nginx
+        state: started
+        enabled: true
+      check_mode: true
+      register: service
+      failed_when: (service is changed) or (service is failed)
+
+    - name: Verify NGINX is up and running
+      ansible.builtin.uri:
+        url: http://localhost
+        status_code: 200
+
+    - name: Check if NGINX Management Suite services are installed
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)
+      loop:
+        - nms
+        - nms-core
+        - nms-dpm
+        - nms-ingestion
+        - nms-integrations
+        - nms-acm
+
+    - name: Verify NGINX Management Suite is up and running
+      ansible.builtin.uri:
+        url: https://localhost/modules
+        status_code: 200
+        validate_certs: false
+        return_content: yes
+        body_format: json
+      register: response
+      failed_when: '"API Connectivity Manager" not in (response.json | map(attribute="name") | list)'

--- a/tasks/nms/install-debian.yml
+++ b/tasks/nms/install-debian.yml
@@ -27,10 +27,28 @@
   register: nms_install_state
   when: nms_cleanup_status is not defined
 
-- name: (Debian/Ubuntu) Make sure NGINX Instance Manager is running
+- name: (Debian/Ubuntu) NMS Modules
+  ansible.builtin.apt:
+    name: "{{ item.name }}={{ '*' if (item.version is not defined or item.version == '') else item.version }}"
+    update_cache: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
+    state: "{{ nms_state if item.setup is not defined else nms_state_vals[item.setup] }}"
+  when: 
+    - nms_cleanup_status is not defined
+    - nms_modules is defined
+  loop: "{{ nms_modules }}"
+  loop_control:
+    label: "{{ item.name }}"
+  notify: 
+    - Restart NGINX Management Suite
+    - Restart NGINX
+
+- name: (Debian/Ubuntu) Make sure NGINX Management Suite is running
   ansible.builtin.systemd:
     state: started
     name: nms
     enabled: true
   notify: Restart NGINX
-  when: nms_cleanup_status is not defined
+  when: 
+    - nms_cleanup_status is not defined
+    - nms_setup | lower != 'uninstall'

--- a/tasks/nms/install-redhat.yml
+++ b/tasks/nms/install-redhat.yml
@@ -33,6 +33,23 @@
   register: nms_install_state
   when: nms_cleanup_status is not defined
 
+- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) NMS Modules
+  ansible.builtin.yum:
+    name: "{{ item.name }}-{{ '*' if (item.version is not defined or item.version == '') else item.version }}"
+    update_cache: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
+    state: "{{ nms_state if item.setup is not defined else nms_state_vals[item.setup] }}"
+    update_only: "{{ nms_setup | lower == 'upgrade' if item.setup is not defined else nms_state_vals[item.setup] | lower == 'upgrade' }}"
+  when: 
+    - nms_cleanup_status is not defined
+    - nms_modules is defined
+  loop: "{{ nms_modules }}"
+  loop_control:
+    label: "{{ item.name }}"
+  notify: 
+    - Restart NGINX Management Suite
+    - Restart NGINX
+
 - name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Make sure NGINX Management Suite is running
   ansible.builtin.systemd:
     state: started
@@ -40,7 +57,9 @@
     enabled: true
   notify: Restart NGINX
   loop: "{{ nms_services | flatten(levels=1) }}"
-  when: nms_cleanup_status is not defined
+  when: 
+    - nms_cleanup_status is not defined
+    - nms_setup | lower != 'uninstall'
 
 - name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Get list of installed packages
   ansible.builtin.yum:
@@ -53,7 +72,10 @@
     permanent: true
     immediate: true
     state: enabled
-  when: nms_cleanup_status is not defined and 'firewalld' in (firewalld_status.results | map(attribute='name') | list)
+  when:
+    - nms_cleanup_status is not defined
+    - '"firewalld" in (firewalld_status.results | map(attribute="name") | list)'
+    - nms_setup | lower != 'uninstall'
   loop:
     - https
     - http


### PR DESCRIPTION
### Proposed changes

Add support to install one or more nms modules.  Config variables can be used with
```
nms_modules:
   - name: nms-api-connectivity-manager
     version: ''
     setup: install
```
where:
- `name` is the name of the module package
- `version` is an optional parameter and takes a version glob, e.g. `1.4.1*`
- `setup` is an optional parameter and follows the same model as `nms_setup`.  It defaults to the value set in `nms_setup` if it is not present.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/CHANGELOG.md))
