### PR TITLE
Update README and resolve CI Fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,31 +216,6 @@ Working functional playbook examples can be found in the **[`molecule/`](https:/
 
 Do note that if you install this repository via Ansible Galaxy, you will have to replace the role variable in the sample playbooks from `ansible-role-nginx-management-suite` to `nginxinc.nginx_management_suite`.
 
-## NGINX Plus Counting
-
-You can use this role to help count the number of NGINX Plus instance you have.
-
-### Requirement
-
-You will also need to install the following collection in order to use the example playbooks for counting NGINX Plus instances.
-
-```yaml
-collections:
-  - name: https://github.com/TuxInvader/ansible_collection_nginx_management_suite.git
-    type: git
-    version: main
-```
-
-### Example NGINX Plus Count Playbook
-
-Example playbooks are also tested as a part of this role and can be found in the table below.
-
-| Name | Description |
-| ---- | ----------- |
-| **[`plus-count-ubuntu/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-ubuntu/converge.yml)** | Install NMS and NGINX Agent on NGINX Plus instances using an Ubuntu NMS Host |
-| **[`plus-count-rhel/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-rhel/converge.yml)** | Install NMS and NGINX Agent on NGINX Plus instances using a RHEL NMS Host |
-| **[`plus-count-upgrade/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-rhel/converge.yml)** | Upgrade NMS and NGINX Agent on NGINX Plus instances using aN Ubuntu NMS Host |
-
 ## Other NGINX Ansible Collections and Roles
 
 You can find the Ansible NGINX Core collection of roles to install and configure NGINX Open Source, NGINX Plus, and NGINX App Protect [here](https://github.com/nginxinc/ansible-collection-nginx).

--- a/docs/nginx-plus-count.md
+++ b/docs/nginx-plus-count.md
@@ -1,0 +1,24 @@
+# NGINX Plus Counting
+
+You can use this role to help count the number of NGINX Plus instance you have.
+
+## Requirement
+
+You will also need to install the following collection in order to use the example playbooks for counting NGINX Plus instances.
+
+```yaml
+collections:
+  - name: https://github.com/TuxInvader/ansible_collection_nginx_management_suite.git
+    type: git
+    version: main
+```
+
+## Example NGINX Plus Count Playbook
+
+Example playbooks are also tested as a part of this role and can be found in the table below.
+
+| Name | Description |
+| ---- | ----------- |
+| **[`plus-count-ubuntu/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-ubuntu/converge.yml)** | Install NMS and NGINX Agent on NGINX Plus instances using an Ubuntu NMS Host |
+| **[`plus-count-rhel/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-rhel/converge.yml)** | Install NMS and NGINX Agent on NGINX Plus instances using a RHEL NMS Host |
+| **[`plus-count-upgrade/converge.yml`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/molecule/plus-count-rhel/converge.yml)** | Upgrade NMS and NGINX Agent on NGINX Plus instances using aN Ubuntu NMS Host |

--- a/molecule/plus-count-rhel/molecule.yml
+++ b/molecule/plus-count-rhel/molecule.yml
@@ -129,8 +129,8 @@ platforms:
       - name: bridge
       - name: hostname_network
     command: /usr/sbin/init
-  - name: debian-buster
-    image: debian:buster-slim
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true

--- a/molecule/plus-count-rhel/molecule.yml
+++ b/molecule/plus-count-rhel/molecule.yml
@@ -139,7 +139,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     groups:
       - data
-      - data_r24
+      - data_r31
     networks:
       - name: bridge
       - name: hostname_network
@@ -155,21 +155,6 @@ platforms:
     groups:
       - data
       - data_r25
-    networks:
-      - name: bridge
-      - name: hostname_network
-    command: /sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    groups:
-      - data
-      - data_r24
     networks:
       - name: bridge
       - name: hostname_network

--- a/molecule/plus-count-rhel/prepare.yml
+++ b/molecule/plus-count-rhel/prepare.yml
@@ -82,8 +82,8 @@
           key: "{{ playbook_dir }}/../../files/license/nginx-repo.key"
 
 
-- name: Prepare NGINX Plus Data Hosts R24
-  hosts: data_r24
+- name: Prepare NGINX Plus Data Hosts R31
+  hosts: data_r31
   tasks:
     - name: Install NGINX Plus
       ansible.builtin.include_role:
@@ -92,7 +92,7 @@
         nginx_selinux: true
         nginx_selinux_enforcing: false
         nginx_type: plus
-        nginx_version: =24*
+        nginx_version: =31*
         nginx_remove_license: false
         nginx_license:
           certificate: "{{ playbook_dir }}/../../files/license/nginx-repo.crt"

--- a/molecule/plus-count-ubuntu/molecule.yml
+++ b/molecule/plus-count-ubuntu/molecule.yml
@@ -130,7 +130,7 @@ platforms:
       - name: hostname_network
     command: /usr/sbin/init
   - name: debian-bookworm
-    image: debian:buster-slim
+    image: debian:bookworm-slim
     platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true

--- a/molecule/plus-count-ubuntu/molecule.yml
+++ b/molecule/plus-count-ubuntu/molecule.yml
@@ -129,7 +129,7 @@ platforms:
       - name: bridge
       - name: hostname_network
     command: /usr/sbin/init
-  - name: debian-buster
+  - name: debian-bookworm
     image: debian:buster-slim
     platform: x86_64
     dockerfile: ../common/Dockerfile.j2
@@ -139,7 +139,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     groups:
       - data
-      - data_r24
+      - data_r31
     networks:
       - name: bridge
       - name: hostname_network
@@ -155,21 +155,6 @@ platforms:
     groups:
       - data
       - data_r25
-    networks:
-      - name: bridge
-      - name: hostname_network
-    command: /sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    groups:
-      - data
-      - data_r24
     networks:
       - name: bridge
       - name: hostname_network

--- a/molecule/plus-count-ubuntu/prepare.yml
+++ b/molecule/plus-count-ubuntu/prepare.yml
@@ -82,8 +82,8 @@
           key: "{{ playbook_dir }}/../../files/license/nginx-repo.key"
 
 
-- name: Prepare NGINX Plus Data Hosts R24
-  hosts: data_r24
+- name: Prepare NGINX Plus Data Hosts R31
+  hosts: data_r31
   tasks:
     - name: Install NGINX Plus
       ansible.builtin.include_role:
@@ -92,7 +92,7 @@
         nginx_selinux: true
         nginx_selinux_enforcing: false
         nginx_type: plus
-        nginx_version: =24*
+        nginx_version: =31*
         nginx_remove_license: false
         nginx_license:
           certificate: "{{ playbook_dir }}/../../files/license/nginx-repo.crt"


### PR DESCRIPTION
### Proposed changes

This PR takes care of the following

1. There were questions about including a private Ansible collection in the README which is not needed for this role to work. It was mainly used to document an example of using this role to count the number of NIGNX Plus instances.
2. Resolve CI failure. The NGINX Plus Count CI is failing because Debian 10 is no longer supported. Removing testing this version.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-management-suite/blob/main/CHANGELOG.md))
