### PR TITLE
ci: pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
 
@@ -61,10 +61,10 @@ jobs:
     needs: ansible-lint
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,6 @@ jobs:
     name: Update release draft
     runs-on: ubuntu-22.04
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin action refs from mutable tags to full commit SHAs to prevent supply-chain attacks.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `34e11487...` |
| `actions/setup-python` | `v5` | `a26af69b...` |
| `release-drafter/release-drafter` | `v6` | `6a93d829...` |

Applied to: `galaxy.yml`, `molecule.yml`, `release-drafter.yml`

No behavioral changes — supply-chain hardening only.